### PR TITLE
feat(social): add DevTools component and implement post simulation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       dompurify:
         specifier: ^3.2.6
         version: 3.2.6
-      eslint-plugin-unused-imports:
-        specifier: ^4.1.4
-        version: 4.1.4(@typescript-eslint/eslint-plugin@8.33.0(@typescript-eslint/parser@8.33.0(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.27.0(jiti@2.4.2))
       firebase:
         specifier: ^11.8.1
         version: 11.8.1
@@ -123,6 +120,9 @@ importers:
       eslint-plugin-storybook:
         specifier: 9.0.0
         version: 9.0.0(eslint@9.27.0(jiti@2.4.2))(storybook@9.0.0(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
+      eslint-plugin-unused-imports:
+        specifier: ^4.1.4
+        version: 4.1.4(@typescript-eslint/eslint-plugin@8.33.0(@typescript-eslint/parser@8.33.0(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.27.0(jiti@2.4.2))
       prettier:
         specifier: ^3.5.3
         version: 3.5.3

--- a/src/app/(social)/_components/dev-tools.tsx
+++ b/src/app/(social)/_components/dev-tools.tsx
@@ -1,0 +1,54 @@
+'use client';
+import { config, Env } from '@/config';
+import { useSuspenseUserInfo } from '@/lib/api/hooks/users';
+import {
+  UrlType,
+  writePostRequest,
+} from '@/lib/api/models/feeds/write-post-request';
+import { ratelApi } from '@/lib/api/ratel_api';
+import { useApiCall } from '@/lib/api/use-send';
+import React, { Fragment } from 'react';
+
+export default function DevTools() {
+  const { data: user } = useSuspenseUserInfo();
+  const { post } = useApiCall();
+
+  if (config.env !== Env.Dev) {
+    return <Fragment />;
+  }
+
+  const handleSimulate = async () => {
+    const title =
+      'DAO Treasury Transparency Act & Crypto Investor Protection Act';
+    const html_contents =
+      'Explore powerful artworks that amplify voices for equality, diversity, and justice. This collection brings...';
+    const user_id = user.id;
+    const industry_id = 1;
+    const quote_feed_id = null;
+    const files = [];
+    const url =
+      'https://metadata.ratel.foundation/metadata/0faf45ec-35e1-40e9-bff2-c61bb52c7d19';
+
+    await post(
+      ratelApi.feeds.writePost(),
+      writePostRequest(
+        html_contents,
+        user_id,
+        industry_id,
+        title,
+        quote_feed_id,
+        files,
+        url,
+        UrlType.Image,
+      ),
+    );
+  };
+
+  return (
+    <div className="px-2 py-5 px-3 w-full rounded-[10px] bg-component-bg">
+      <button className="sidemenu-link" onClick={handleSimulate}>
+        <span>Simulate a post</span>
+      </button>
+    </div>
+  );
+}

--- a/src/app/(social)/_components/user-sidemenu.tsx
+++ b/src/app/(social)/_components/user-sidemenu.tsx
@@ -9,6 +9,7 @@ import { useUserInfo } from '@/lib/api/hooks/users';
 import Link from 'next/link';
 import { route } from '@/route';
 import { Post, Settings } from '@/components/icons';
+import DevTools from './dev-tools';
 
 export default function UserSidemenu() {
   const { data: user, isLoading } = useUserInfo();
@@ -31,6 +32,8 @@ export default function UserSidemenu() {
           <span>Settings</span>
         </Link>
       </nav>
+
+      <DevTools />
 
       <RecentActivities />
 

--- a/src/app/(social)/_hooks/use-posts.ts
+++ b/src/app/(social)/_hooks/use-posts.ts
@@ -1,0 +1,24 @@
+import { ratelApi } from '@/lib/api/ratel_api';
+import { QueryResponse } from '@/lib/api/models/common';
+import { Feed } from '@/lib/api/models/feeds';
+import { useApiCall } from '@/lib/api/use-send';
+import {
+  useSuspenseQuery,
+  UseSuspenseQueryResult,
+} from '@tanstack/react-query';
+import { QK_USERS_GET_INFO } from '@/constants';
+
+export function usePost(
+  page: number,
+  size: number,
+): UseSuspenseQueryResult<QueryResponse<Feed>> {
+  const { get } = useApiCall();
+
+  const query = useSuspenseQuery({
+    queryKey: [QK_USERS_GET_INFO],
+    queryFn: () => get(ratelApi.feeds.getPosts(page, size)),
+    refetchOnWindowFocus: false,
+  });
+
+  return query;
+}

--- a/src/app/(social)/page.tsx
+++ b/src/app/(social)/page.tsx
@@ -1,75 +1,54 @@
 'use client';
-
 import Image from 'next/image';
-import {
-  Award,
-  MoreHorizontal,
-  ChevronRight,
-  Star,
-  MessageSquare,
-  Building,
-  Eye,
-  Repeat,
-} from 'lucide-react';
+import { Award, ChevronRight } from 'lucide-react';
 import FeedCard from '@/components/feed-card';
+import { usePost } from './_hooks/use-posts';
+import { logger } from '@/lib/logger';
+import { Col } from '@/components/ui/col';
+
+export interface Post {
+  id: number;
+  industry: string;
+  title: string;
+  contents: string;
+  url?: string;
+  author_profile_url: string;
+  author_name: string;
+  likes: number;
+  comments: number;
+  rewards: number;
+  shares: number;
+  created_at: number;
+}
 
 export default function Home() {
-  const feeds = [
-    {
-      id: 1,
-      industry: 'Crypto',
-      title: 'DAO Treasury Transparency Act & Crypto Investor Protection Act',
-      contents:
-        'Explore powerful artworks that amplify voices for equality, diversity, and justice. This collection brings...',
-      url: '/post-placeholder.jpg?height=300&width=500',
-      author_profile_url:
-        'https://metadata.ratel.foundation/metadata/0faf45ec-35e1-40e9-bff2-c61bb52c7d19',
-      author_name: 'Miner Choi',
+  const { data } = usePost(1, 20);
+  logger.debug('query response of posts', data);
+  const feeds: Post[] = data.items.map((item) => ({
+    id: item.id,
+    industry: 'Crypto', // FIXME:replace with actual industry
+    title: item.title!,
+    contents: item.html_contents,
+    url: item.url,
+    // FIXME:replace with actual author profile URL
+    author_profile_url:
+      'https://metadata.ratel.foundation/metadata/0faf45ec-35e1-40e9-bff2-c61bb52c7d19',
+    author_name: 'Miner Choi',
 
-      likes: 10,
-      comments: 100,
-      rewards: 221000,
-      shares: 403,
-      created_at: 0,
-    },
-  ];
+    likes: item.likes,
+    comments: item.comments,
+    rewards: item.rewards,
+    shares: item.shares,
+    created_at: item.created_at,
+  }));
 
   return (
     <div className="flex-1 flex">
-      {/* Feed */}
-      <div className="flex-1 border-r border-gray-800">
-        {/* Tabs */}
-        <div className="flex border-b border-gray-800">
-          <div className="px-6 py-3 text-sm font-medium">For you</div>
-          <div className="px-6 py-3 text-sm text-gray-400">Following</div>
-        </div>
-
-        {/* Post Input */}
-        <div className="p-4 border-b border-gray-800">
-          <div className="flex gap-3">
-            <Image
-              src="/profile.png?height=40&width=40"
-              alt="Profile"
-              width={40}
-              height={40}
-              className="rounded-full"
-            />
-            <input
-              type="text"
-              placeholder="Discuss legislation. Drive change."
-              className="w-full bg-gray-800 rounded-full pl-10 pr-4 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-[#fcb300]"
-            />
-            {/* <div className="flex-1 bg-gray-800 rounded-full px-4 py-2 text-gray-400 text-sm">
-                                    Discuss legislation. Drive change.
-                                </div> */}
-          </div>
-        </div>
-
-        {/* Posts */}
+      <Col className="flex-1 border-r border-gray-800">
         {feeds.map((props) => (
-          <FeedCard {...props}> </FeedCard>
+          <FeedCard key={`feed-${props.id}`} {...props} />
         ))}
-      </div>
+      </Col>
 
       {/* Right Sidebar */}
       <div className="w-80 p-4">

--- a/src/components/feed-card.tsx
+++ b/src/components/feed-card.tsx
@@ -5,6 +5,7 @@ import { Row } from './ui/row';
 import { CommentIcon, Rewards, Shares, ThumbUp } from './icons';
 import { convertNumberToString } from '@/lib/number-utils';
 import TimeAgo from './time-ago';
+import DOMPurify from 'dompurify';
 
 export interface FeedCardProps {
   id: number;
@@ -67,11 +68,14 @@ export function FeedContents({
   contents: string;
   url?: string;
 }) {
+  const c = DOMPurify.sanitize(contents);
+
   return (
     <Col className="text-white">
-      <p className="font-normal text-[15px]/[24px] align-middle tracking-[0.5px] text-c-wg-30">
-        {contents}
-      </p>
+      <p
+        className="font-normal text-[15px]/[24px] align-middle tracking-[0.5px] text-c-wg-30"
+        dangerouslySetInnerHTML={{ __html: c }}
+      ></p>
       {url && <img className="w-full rounded-[8px]" src={url} />}
     </Col>
   );

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 type Config = {
-  env: string;
+  env: Env;
   firebase_api_key: string;
   firebase_auth_domain: string;
   firebase_project_id: string;
@@ -15,8 +15,15 @@ type Config = {
   graphql_url: string;
 };
 
+export enum Env {
+  Local = 'local',
+  Dev = 'dev',
+  Staging = 'stg',
+  Prod = 'prod',
+}
+
 export const config: Config = {
-  env: process.env.NEXT_PUBLIC_ENV || 'dev',
+  env: (process.env.NEXT_PUBLIC_ENV || 'dev') as Env,
   firebase_api_key: process.env.NEXT_PUBLIC_FIREBASE_API_KEY || '',
   firebase_auth_domain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN || '',
   firebase_project_id: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || '',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,3 +6,4 @@ export const SK_ANONYMOUS_IDENTITY_KEY = 'anonymous_identity';
 export const QK_USERS_GET_INFO = 'user-get-info';
 export const QK_USERS_PROFILE = 'user-profile';
 export const QK_ASSETS_GET_PRESIGNED_URL = 'assets-get-presigned-url';
+export const QK_GET_POSTS = 'get-posts';

--- a/src/lib/api/hooks/users.ts
+++ b/src/lib/api/hooks/users.ts
@@ -28,9 +28,7 @@ export function useUserInfo(): UseQueryResult<User | undefined> {
   return query;
 }
 
-export function useSuspenseUserInfo(): UseSuspenseQueryResult<
-  User | undefined
-> {
+export function useSuspenseUserInfo(): UseSuspenseQueryResult<User> {
   const { get } = useApiCall();
   const auth = useAuth();
   const principalText = auth.ed25519KeyPair?.getPrincipal().toText();

--- a/src/lib/api/models/common.ts
+++ b/src/lib/api/models/common.ts
@@ -1,0 +1,4 @@
+export interface QueryResponse<T> {
+  total_count: number;
+  items: T[];
+}

--- a/src/lib/api/models/feeds.ts
+++ b/src/lib/api/models/feeds.ts
@@ -1,3 +1,5 @@
+import { UrlType } from './feeds/write-post-request';
+
 export interface Feed {
   id: number;
   created_at: number;
@@ -21,9 +23,12 @@ export interface Feed {
   likes: number;
   comments: number;
 
-  files: File[];
+  files: FileInfo[];
   rewards: number;
   shares: number;
+
+  url?: string;
+  url_type: UrlType;
 }
 
 export enum FeedType {
@@ -33,7 +38,7 @@ export enum FeedType {
   DocReview = 4,
 }
 
-export interface File {
+export interface FileInfo {
   name: string;
   size: string;
   ext: FileExtension;

--- a/src/lib/api/models/feeds/WritePostRequest.ts
+++ b/src/lib/api/models/feeds/WritePostRequest.ts
@@ -1,0 +1,10 @@
+export interface WritePostRequest {
+  write: {
+    html_contents: string;
+    user_id: number;
+    industry_id: number;
+    title: string;
+    quote_feed_id: number | null;
+    files: File[] | null;
+  };
+}

--- a/src/lib/api/models/feeds/write-post-request.ts
+++ b/src/lib/api/models/feeds/write-post-request.ts
@@ -1,0 +1,43 @@
+import { FileInfo } from '../feeds';
+
+export interface WritePostRequest {
+  write_post: {
+    html_contents: string;
+    user_id: number;
+    industry_id: number;
+    title: string;
+    quote_feed_id: number | null;
+    files: FileInfo[] | null;
+    url: string | null;
+    url_type: UrlType;
+  };
+}
+
+export enum UrlType {
+  None = 0,
+  Image = 1,
+}
+
+export function writePostRequest(
+  html_contents: string,
+  user_id: number,
+  industry_id: number,
+  title: string,
+  quote_feed_id: number | null,
+  files: FileInfo[],
+  url: string | null,
+  url_type: UrlType = UrlType.None,
+): WritePostRequest {
+  return {
+    write_post: {
+      html_contents,
+      user_id,
+      industry_id,
+      title,
+      quote_feed_id,
+      files,
+      url,
+      url_type,
+    },
+  };
+}

--- a/src/lib/api/ratel_api.ts
+++ b/src/lib/api/ratel_api.ts
@@ -13,6 +13,12 @@ export const ratelApi = {
   teams: {
     createTeam: () => '/v1/teams',
   },
+  feeds: {
+    writePost: () => '/v1/feeds',
+    getPosts: (page: number, size: number) =>
+      `/v1/feeds?param-type=query&bookmark=${page}&size=${size}`,
+  },
+
   graphql: {
     listIndustries: () => {
       return {


### PR DESCRIPTION
- Introduced a new `DevTools` component for development environment tools.
- Added a "Simulate a post" button to create mock posts for testing.
- Integrated `usePost` hook to fetch posts dynamically from the API.
- Updated `FeedCard` to sanitize and render HTML content safely using `DOMPurify`.
- Enhanced `Home` page to display posts fetched via the new API.
- Refactored `config` to use an `Env` enum for better type safety.
- Added new API endpoints for writing and fetching posts in `ratelApi`.
- Updated `Feed` model to include `url` and `url_type` fields.
- Introduced `WritePostRequest` and `UrlType` for structured post creation.
- Fixed type definition for `useSuspenseUserInfo` to ensure non-undefined user data.