### PR TITLE
feat(social): add user type check for rendering components

### DIFF
--- a/src/app/(social)/layout.tsx
+++ b/src/app/(social)/layout.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react';
 import { useUserInfo } from '@/lib/api/hooks/users';
 import UserSidemenu from './_components/user-sidemenu';
 import Loading from '../loading';
+import { UserType } from '@/lib/api/models/user';
 
 export default function SocialLayout({
   children,
@@ -13,7 +14,10 @@ export default function SocialLayout({
 
   return (
     <div className="flex min-h-screen gap-5 justify-between max-w-6xl mx-auto text-white py-3 px-2.5">
-      {!isLoading && user && <UserSidemenu />}
+      {!isLoading &&
+        user &&
+        (user.user_type === UserType.Individual ||
+          user.user_type === UserType.Team) && <UserSidemenu />}
 
       <div className="flex-1 flex">
         <Suspense

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -16,6 +16,7 @@ import { logger } from '@/lib/logger';
 import { route } from '@/route';
 import { config } from '@/config';
 import { useUserInfo } from '@/lib/api/hooks/users';
+import { UserType } from '@/lib/api/models/user';
 
 export interface HeaderProps {
   mobileExtends: boolean;
@@ -117,7 +118,10 @@ function Header(props: HeaderProps) {
             </Link>
           ))}
 
-          {!isLoading && data ? (
+          {!isLoading &&
+          data &&
+          (data.user_type === UserType.Individual ||
+            data?.user_type === UserType.Team) ? (
             <Profile profileUrl={data.profile_url} name={data.nickname} />
           ) : (
             <button


### PR DESCRIPTION
Ensure components like `UserSidemenu` and `Profile` are rendered only for specific user types (`Individual` or `Team`). This adds a conditional check based on `user_type` in `SocialLayout` and `Header`.